### PR TITLE
Implement residual risk calculation

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from scanner.discovery import discover_subdomains
 from logic.valuation import evaluate_assets
 from logic.risks import identify_risks
 from logic.treatment import generate_treatments
+from logic.residual import calculate_residual
 
 app = Flask(__name__)
 
@@ -20,9 +21,13 @@ def results(domain):
     valoraciones = evaluate_assets(activos)
     riesgos = identify_risks(activos)
     tratamientos = generate_treatments(riesgos)
-    return render_template("results.html", domain=domain,
-                           activos=activos, valoraciones=valoraciones,
-                           riesgos=riesgos, tratamientos=tratamientos)
+    residuales = calculate_residual(tratamientos, valoraciones, riesgos)
+    return render_template(
+        "results.html", domain=domain,
+        activos=activos, valoraciones=valoraciones,
+        riesgos=riesgos, tratamientos=tratamientos,
+        residuales=residuales
+    )
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000)

--- a/logic/residual.py
+++ b/logic/residual.py
@@ -1,0 +1,63 @@
+def calculate_residual(tratamientos, valoraciones, riesgos):
+    """Compute residual risk after applying treatments.
+
+    Args:
+        tratamientos (list): treatment plan items with 'id', 'accion', etc.
+        valoraciones (list): asset valuations including 'id' and 'valor'.
+        riesgos (list): original risk identification entries.
+
+    Returns:
+        list: residual risk entries containing id, subdominio, original risk,
+        control applied, probability, impact, residual risk score and
+        classification.
+    """
+    val_map = {v['id']: v for v in valoraciones}
+    risk_map = {r['id']: r for r in riesgos}
+    residual = []
+
+    for t in tratamientos:
+        id_ = t['id']
+        sub = t['subdominio']
+        control = t['accion']
+        original = risk_map.get(id_, {}).get('riesgo', t.get('riesgo', 'N/A'))
+        valor = val_map.get(id_, {}).get('valor', 0)
+
+        # Impact based on asset valuation
+        if valor <= 6:
+            impacto = 1
+        elif valor <= 12:
+            impacto = 2
+        else:
+            impacto = 3
+
+        # Probability estimation based on action keywords
+        if any(k in control.lower() for k in ['eliminar', 'habilitar', 'configurar', 'agregar', 'autenticaci', 'https', 'mfa']):
+            probabilidad = 1
+        elif 'revisar' in control.lower():
+            probabilidad = 3
+        else:
+            probabilidad = 2
+
+        riesgo_residual = probabilidad * impacto
+
+        if riesgo_residual == 0:
+            clas = 'Nulo'
+        elif riesgo_residual <= 2:
+            clas = 'Bajo'
+        elif riesgo_residual <= 4:
+            clas = 'Medio'
+        else:
+            clas = 'Alto'
+
+        residual.append({
+            'id': id_,
+            'subdominio': sub,
+            'riesgo_original': original,
+            'control': control,
+            'probabilidad': probabilidad,
+            'impacto': impacto,
+            'riesgo_residual': riesgo_residual,
+            'clasificacion': clas
+        })
+
+    return residual

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -10,6 +10,7 @@ button:hover{background:#0056b3;}
 table{width:100%;border-collapse:collapse;margin-top:10px;}
 table,th,td{border:1px solid #a0bcd4;}
 th,td{padding:8px;text-align:center;}
+.nulo{background-color:#e2e3e5;}/* gris claro */
 .bajo{background-color:#d4edda;}/* verde claro */
 .medio{background-color:#fff3cd;}/* amarillo claro */
 .alto{background-color:#f8d7da;}/* rojo claro */

--- a/templates/results.html
+++ b/templates/results.html
@@ -55,7 +55,30 @@
                     {% endfor %}
                 </table>
             </div>
-            <div id="residual" style="display:none;"><p>[Riesgo residual aparecerá aquí]</p></div>
+            <div id="residual" style="display:none;">
+                <table>
+                    <tr>
+                        <th>Subdominio</th>
+                        <th>Riesgo Original</th>
+                        <th>Control Aplicado</th>
+                        <th>Probabilidad</th>
+                        <th>Impacto</th>
+                        <th>Riesgo Residual</th>
+                        <th>Clasificación</th>
+                    </tr>
+                    {% for r in residuales %}
+                    <tr class="{{ r.clasificacion|lower }}">
+                        <td>{{ r.subdominio }}</td>
+                        <td>{{ r.riesgo_original }}</td>
+                        <td>{{ r.control }}</td>
+                        <td>{{ r.probabilidad }}</td>
+                        <td>{{ r.impacto }}</td>
+                        <td>{{ r.riesgo_residual }}</td>
+                        <td>{{ r.clasificacion }}</td>
+                    </tr>
+                    {% endfor %}
+                </table>
+            </div>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- calculate residual risk after treatments
- show table of residual scores
- color-code `nulo` entries in CSS
- wire up residual risk results in app

## Testing
- `python -m py_compile app.py logic/*.py scanner/*.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686bd334a4cc832cb920124356714b28