### PR TITLE
Add Bootstrap styling

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -9,9 +9,6 @@ h1,h2,h3,h4{color:#1f2d3d;margin-bottom:1rem;}
 input[type="text"]{width:100%;padding:10px;border:1px solid #b0c4de;border-radius:6px;}
 button{background:#007bff;color:white;border:none;padding:10px 20px;margin-top:10px;border-radius:6px;cursor:pointer;}
 button:hover{background:#0056b3;}
-.tabs{display:flex;margin-top:20px;}
-.tab{flex:1;padding:10px;background:#e0ecff;text-align:center;cursor:pointer;border:1px solid #ccc;}
-.tab:hover{background:#d0e2ff;}
 .tab-content{margin-top:20px;}
 table{width:100%;border-collapse:collapse;margin-top:10px;}
 table,th,td{border:1px solid #a0bcd4;}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,13 +1,21 @@
 <!DOCTYPE html>
-<html><head><title>RiskManager</title>
-<link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-</head><body>
-<div class="container">
-  <h2>Evaluación de Riesgo Cibernético</h2>
-  <form method="post">
-    <label for="domain">Ingrese el dominio a analizar:</label><br>
-    <input type="text" name="domain" id="domain" placeholder="ejemplo.com" required>
-    <button type="submit">Analizar</button>
-  </form>
-</div>
-</body></html>
+<html>
+<head>
+  <title>RiskManager</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+  <div class="container mt-5">
+    <h2 class="mb-3">Evaluación de Riesgo Cibernético</h2>
+    <form method="post">
+      <div class="mb-3">
+        <label for="domain" class="form-label">Ingrese el dominio a analizar:</label>
+        <input type="text" class="form-control" name="domain" id="domain" placeholder="ejemplo.com" required>
+      </div>
+      <button type="submit" class="btn btn-primary">Analizar</button>
+    </form>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/results.html
+++ b/templates/results.html
@@ -2,28 +2,42 @@
 <html>
 <head>
     <title>Resultados - {{ domain }}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <script>
         function showTab(tabId) {
             document.querySelectorAll('.tab-content > div').forEach(d => d.style.display = 'none');
             document.getElementById(tabId).style.display = 'block';
+            document.querySelectorAll('.nav-link').forEach(l => l.classList.remove('active'));
+            const link = document.querySelector(`[data-tab="${tabId}"]`);
+            if (link) link.classList.add('active');
         }
         window.onload = () => showTab('activos');
     </script>
 </head>
 <body>
-    <div class="container">
-        <h2>Resultados para: {{ domain }}</h2>
-        <div class="tabs">
-            <div class="tab" onclick="showTab('activos')">Activos encontrados</div>
-            <div class="tab" onclick="showTab('valoracion')">Valoración de activos</div>
-            <div class="tab" onclick="showTab('riesgos')">Identificación de riesgos</div>
-            <div class="tab" onclick="showTab('tratamiento')">Tratamiento</div>
-            <div class="tab" onclick="showTab('residual')">Riesgo residual</div>
-        </div>
-        <div class="tab-content">
+    <div class="container mt-5">
+        <h2 class="mb-3">Resultados para: {{ domain }}</h2>
+        <ul class="nav nav-tabs">
+            <li class="nav-item">
+                <a class="nav-link active" href="#" data-tab="activos" onclick="showTab('activos')">Activos encontrados</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="#" data-tab="valoracion" onclick="showTab('valoracion')">Valoración de activos</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="#" data-tab="riesgos" onclick="showTab('riesgos')">Identificación de riesgos</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="#" data-tab="tratamiento" onclick="showTab('tratamiento')">Tratamiento</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="#" data-tab="residual" onclick="showTab('residual')">Riesgo residual</a>
+            </li>
+        </ul>
+        <div class="tab-content mt-3">
             <div id="activos">
-                <table>
+                <table class="table table-bordered table-sm">
                     <tr><th>ID</th><th>Subdominio</th><th>IP</th><th>Registro</th><th>Estado</th></tr>
                     {% for item in activos %}
                     <tr><td>{{ item.id }}</td><td>{{ item.subdominio }}</td><td>{{ item.ip }}</td><td>{{ item.registro }}</td><td>{{ item.estado }}</td></tr>
@@ -31,7 +45,7 @@
                 </table>
             </div>
             <div id="valoracion" style="display:none;">
-                <table>
+                <table class="table table-bordered table-sm">
                     <tr><th>ID</th><th>Subdominio</th><th>C</th><th>I</th><th>D</th><th>F</th><th>Valor</th><th>Clasificación</th></tr>
                     {% for v in valoraciones %}
                     <tr class="{{ v.clasificacion|lower }}">
@@ -40,7 +54,7 @@
                 </table>
             </div>
             <div id="riesgos" style="display:none;">
-                <table>
+                <table class="table table-bordered table-sm">
                     <tr><th>ID</th><th>Subdominio</th><th>Amenaza Identificada</th><th>Vulnerabilidad Técnica</th><th>Riesgo Potencial</th></tr>
                     {% for r in riesgos %}
                     <tr><td>{{ r.id }}</td><td>{{ r.subdominio }}</td><td>{{ r.amenaza }}</td><td>{{ r.vulnerabilidad }}</td><td>{{ r.riesgo }}</td></tr>
@@ -48,7 +62,7 @@
                 </table>
             </div>
             <div id="tratamiento" style="display:none;">
-                <table>
+                <table class="table table-bordered table-sm">
                     <tr><th>ID</th><th>Subdominio</th><th>Riesgo</th><th>Acción sugerida</th><th>Responsable</th><th>Plazo</th><th>Estado</th></tr>
                     {% for t in tratamientos %}
                     <tr><td>{{ t.id }}</td><td>{{ t.subdominio }}</td><td>{{ t.riesgo }}</td><td>{{ t.accion }}</td><td>{{ t.responsable }}</td><td>{{ t.plazo }}</td><td>{{ t.estado }}</td></tr>
@@ -56,7 +70,7 @@
                 </table>
             </div>
             <div id="residual" style="display:none;">
-                <table>
+                <table class="table table-bordered table-sm">
                     <tr>
                         <th>Subdominio</th>
                         <th>Riesgo Original</th>
@@ -79,7 +93,8 @@
                     {% endfor %}
                 </table>
             </div>
-        </div>
+    </div>
     </div>
 </body>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </html>


### PR DESCRIPTION
## Summary
- integrate Bootstrap 5 via CDN in templates
- convert form and results tabs to use Bootstrap classes
- clean up old tab styles in CSS

## Testing
- `python -m py_compile app.py logic/*.py scanner/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686c3aee9d64832cb276633b5f69a5f1