### PR TITLE
Improve aesthetics and embed favicon

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -7,13 +7,19 @@ body{font-family:Roboto, Arial, sans-serif;background:#f4f9ff;color:#1f2d3d;marg
 }
 h1,h2,h3,h4{color:#1f2d3d;margin-bottom:1rem;}
 input[type="text"]{width:100%;padding:10px;border:1px solid #b0c4de;border-radius:6px;}
-button{background:#007bff;color:white;border:none;padding:10px 20px;margin-top:10px;border-radius:6px;cursor:pointer;}
+button{background:#007bff;color:white;border:none;padding:10px 20px;margin-top:10px;border-radius:6px;cursor:pointer;transition:background .3s;}
 button:hover{background:#0056b3;}
 .tab-content{margin-top:20px;}
+input[type="text"]:focus{outline:none;border-color:#80bdff;box-shadow:0 0 0 0.2rem rgba(0,123,255,.25);}
 table{width:100%;border-collapse:collapse;margin-top:10px;}
+table tr:nth-child(even){background:#f8f9fe;}
+table tbody tr:hover{background:#eef6ff;}
 table,th,td{border:1px solid #a0bcd4;}
 th,td{padding:10px;text-align:center;color:#1f2d3d;}
 th{background:#e0ecff;}
+.nav-tabs .nav-link{color:#007bff;}
+.nav-tabs .nav-link:hover{color:#0056b3;}
+.nav-tabs .nav-link.active{background:#007bff;color:white;}
 .nulo{background-color:#e2e3e5;}/* gris claro */
 .bajo{background-color:#d4edda;}/* verde claro */
 .medio{background-color:#fff3cd;}/* amarillo claro */

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,7 @@
 <head>
   <title>RiskManager</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkqP7PQApgIkn1qIZRDUNKAwC1+QGaBFISYQAAAABJRU5ErkJggg==">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>

--- a/templates/results.html
+++ b/templates/results.html
@@ -3,6 +3,7 @@
 <head>
     <title>Resultados - {{ domain }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGUlEQVR4nGNkqP7PQApgIkn1qIZRDUNKAwC1+QGaBFISYQAAAABJRU5ErkJggg==">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <script>
         function showTab(tabId) {


### PR DESCRIPTION
## Summary
- enhance buttons, tables and form field focus style
- embed favicon with base64 in HTML templates
- remove icon files from repository

## Testing
- `python3 -m py_compile app.py logic/*.py scanner/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686c38196c94832cb58bafce07b57fa6