### PR TITLE
Show ID column in residual risk table

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -73,6 +73,7 @@
             <div id="residual" style="display:none;">
                 <table class="table table-bordered table-sm">
                     <tr>
+                        <th>ID</th>
                         <th>Subdominio</th>
                         <th>Riesgo Original</th>
                         <th>Control Aplicado</th>
@@ -83,6 +84,7 @@
                     </tr>
                     {% for r in residuales %}
                     <tr class="{{ r.clasificacion|lower }}">
+                        <td>{{ r.id }}</td>
                         <td>{{ r.subdominio }}</td>
                         <td>{{ r.riesgo_original }}</td>
                         <td>{{ r.control }}</td>


### PR DESCRIPTION
## Summary
- add ID column in residual risk results table

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c579beae0832c86414473d2001fd0