### PR TITLE
Add HTTPS security checks to discovery

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -39,9 +39,9 @@
         <div class="tab-content mt-3">
             <div id="activos">
                 <table class="table table-bordered table-sm">
-                    <tr><th>ID</th><th>Subdominio</th><th>IP</th><th>Registro</th><th>Estado</th></tr>
+                    <tr><th>ID</th><th>Subdominio</th><th>IP</th><th>Registro</th><th>Estado</th><th>Observaciones</th></tr>
                     {% for item in activos %}
-                    <tr><td>{{ item.id }}</td><td>{{ item.subdominio }}</td><td>{{ item.ip }}</td><td>{{ item.registro }}</td><td>{{ item.estado }}</td></tr>
+                    <tr><td>{{ item.id }}</td><td>{{ item.subdominio }}</td><td>{{ item.ip }}</td><td>{{ item.registro }}</td><td>{{ item.estado }}</td><td>{{ item.observaciones }}</td></tr>
                     {% endfor %}
                 </table>
             </div>


### PR DESCRIPTION
## Summary
- extend discovery to perform HTTPS request when available
- check HSTS and CSP headers and save notes as `observaciones`
- show `Observaciones` in results table

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c5a9d7834832c965b004ad2347249