### PR TITLE
Add impact-based risk scoring

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ def index():
 def results(domain):
     activos = discover_subdomains(domain)
     valoraciones = evaluate_assets(activos)
-    riesgos = identify_risks(activos)
+    riesgos = identify_risks(activos, valoraciones)
     tratamientos = generate_treatments(riesgos)
     residuales = calculate_residual(tratamientos, valoraciones, riesgos)
     return render_template(


### PR DESCRIPTION
## Summary
- compute impact using valuations in `identify_risks`
- rate probability and calculate numeric risk score
- return classification using updated ranges
- pass valuations when generating risks

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db0b21e48832cbb0310db6a1b6e47