### PR TITLE
Add impact-based risk scoring

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,7 @@ def index():
 def results(domain):
     activos = discover_subdomains(domain)
     valoraciones = evaluate_assets(activos)
-    riesgos = identify_risks(activos)
+    riesgos = identify_risks(activos, valoraciones)
     tratamientos = generate_treatments(riesgos)
     residuales = calculate_residual(tratamientos, valoraciones, riesgos)
     return render_template(

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -40,3 +40,10 @@ th{background:#e0ecff;}
     background-color:#f8d7da !important;
     --bs-table-bg:#f8d7da !important;
 }/* rojo claro */
+.critico,
+.critico td,
+.crítico,
+.crítico td{
+    background-color:#f5b7b7 !important;
+    --bs-table-bg:#f5b7b7 !important;
+}/* rojo más intenso */

--- a/templates/results.html
+++ b/templates/results.html
@@ -56,9 +56,27 @@
             </div>
             <div id="riesgos" style="display:none;">
                 <table class="table table-bordered table-sm">
-                    <tr><th>ID</th><th>Subdominio</th><th>Amenaza Identificada</th><th>Vulnerabilidad Técnica</th><th>Riesgo Potencial</th></tr>
+                    <tr>
+                        <th>Subdominio</th>
+                        <th>CIA×F</th>
+                        <th>Amenaza</th>
+                        <th>Vulnerabilidad</th>
+                        <th>Prob.</th>
+                        <th>Impacto</th>
+                        <th>Nivel de Riesgo</th>
+                        <th>Clasificación</th>
+                    </tr>
                     {% for r in riesgos %}
-                    <tr><td>{{ r.id }}</td><td>{{ r.subdominio }}</td><td>{{ r.amenaza }}</td><td>{{ r.vulnerabilidad }}</td><td>{{ r.riesgo }}</td></tr>
+                    <tr class="{{ r.clasificacion|lower }}">
+                        <td>{{ r.subdominio }}</td>
+                        <td>{{ r.impacto }}</td>
+                        <td>{{ r.amenaza }}</td>
+                        <td>{{ r.vulnerabilidad }}</td>
+                        <td>{{ r.probabilidad }}</td>
+                        <td>{{ r.impacto }}</td>
+                        <td>{{ r.nivel_riesgo }}</td>
+                        <td>{{ r.clasificacion }}</td>
+                    </tr>
                     {% endfor %}
                 </table>
             </div>


### PR DESCRIPTION
## Summary
- compute impact using valuations in `identify_risks`
- rate probability and calculate numeric risk score
- return classification using updated ranges
- pass valuations when generating risks
- show numeric values in the risk table

## Testing
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686db0b21e48832cbb0310db6a1b6e47