### PR TITLE
Add classification and strategy columns to treatments table

### DIFF
--- a/logic/treatment.py
+++ b/logic/treatment.py
@@ -42,12 +42,14 @@ def generate_treatments(riesgos):
             plazo = '10 días'
             controles = ['MFA', 'DNSSEC', 'CSP']
 
-        estrategia = estrategia_map.get(item.get('clasificacion', 'Medio'), 'Mitigar')
+        clasificacion = item.get('clasificacion', 'Medio')
+        estrategia = estrategia_map.get(clasificacion, 'Mitigar')
 
         plan.append({
             'id': id_,
             'subdominio': sub,
             'riesgo': item['riesgo'],
+            'clasificacion': clasificacion,
             'accion': accion,
             'responsable': 'Seguridad TI',
             'plazo': plazo,

--- a/templates/results.html
+++ b/templates/results.html
@@ -82,9 +82,31 @@
             </div>
             <div id="tratamiento" style="display:none;">
                 <table class="table table-bordered table-sm">
-                    <tr><th>ID</th><th>Subdominio</th><th>Riesgo</th><th>Acción sugerida</th><th>Responsable</th><th>Plazo</th><th>Estado</th></tr>
+                    <tr>
+                        <th>ID</th>
+                        <th>Subdominio</th>
+                        <th>Riesgo</th>
+                        <th>Clasificación</th>
+                        <th>Estrategia</th>
+                        <th>Controles</th>
+                        <th>Acción sugerida</th>
+                        <th>Responsable</th>
+                        <th>Plazo</th>
+                        <th>Estado</th>
+                    </tr>
                     {% for t in tratamientos %}
-                    <tr><td>{{ t.id }}</td><td>{{ t.subdominio }}</td><td>{{ t.riesgo }}</td><td>{{ t.accion }}</td><td>{{ t.responsable }}</td><td>{{ t.plazo }}</td><td>{{ t.estado }}</td></tr>
+                    <tr class="{{ t.clasificacion|lower }}">
+                        <td>{{ t.id }}</td>
+                        <td>{{ t.subdominio }}</td>
+                        <td>{{ t.riesgo }}</td>
+                        <td>{{ t.clasificacion }}</td>
+                        <td>{{ t.estrategia }}</td>
+                        <td>{{ t.controles|join(', ') }}</td>
+                        <td>{{ t.accion }}</td>
+                        <td>{{ t.responsable }}</td>
+                        <td>{{ t.plazo }}</td>
+                        <td>{{ t.estado }}</td>
+                    </tr>
                     {% endfor %}
                 </table>
             </div>


### PR DESCRIPTION
## Summary
- include risk classification and strategy in treatment generation
- show classification, strategy, and controls on the "Tratamiento" table

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dbc39510c832cbc3af2b41b9e44f7