### PR TITLE
Mark primary controls for residual risk calculations

### DIFF
--- a/logic/treatment.py
+++ b/logic/treatment.py
@@ -1,6 +1,33 @@
-def generate_treatments(riesgos):
+def _control_priority(control):
+    """Return a priority score for selecting a primary control.
+
+    Los controles clasificados como "robustos" obtienen una puntuación de 3,
+    los "básicos" 2 y los de tipo organizacional 1.  El control con la mayor
+    puntuación se marca como ``control_principal``.
     """
-    Genera sugerencias de tratamiento para cada riesgo identificado.
+    robust = {
+        'MFA', 'DNSSEC', 'CAA', 'Tokens', 'Rate limiting', 'CSP'
+    }
+    basic = {
+        'HTTPS', 'SPF', 'DKIM', 'DMARC'
+    }
+    organisational = {
+        'Revisión de roles', 'Monitoreo de DNS'
+    }
+    if control in robust:
+        return 3
+    if control in basic:
+        return 2
+    if control in organisational:
+        return 1
+    return 0
+
+
+def generate_treatments(riesgos):
+    """Genera un plan de tratamiento para cada riesgo.
+
+    Se asigna un ``control_principal`` eligiendo el control más robusto de la
+    lista de controles sugeridos mediante :func:`_control_priority`.
     """
     plan = []
 
@@ -44,6 +71,7 @@ def generate_treatments(riesgos):
 
         clasificacion = item.get('clasificacion', 'Medio')
         estrategia = estrategia_map.get(clasificacion, 'Mitigar')
+        control_principal = max(controles, key=_control_priority) if controles else None
 
         plan.append({
             'id': id_,
@@ -55,6 +83,7 @@ def generate_treatments(riesgos):
             'plazo': plazo,
             'estrategia': estrategia,
             'controles': controles,
+            'control_principal': control_principal,
             'estado': 'Planificado'
         })
 


### PR DESCRIPTION
## Summary
- mark a `control_principal` when generating treatment plans
- reduce residual risk based on that primary control
- document how primary controls are selected

## Testing
- `python3 -m py_compile logic/treatment.py logic/residual.py`
- `python3 - <<'PY'
from logic.treatment import generate_treatments
from logic.residual import calculate_residual

riesgos=[{'id':'1','subdominio':'test','amenaza':'Acceso no autorizado','riesgo':'R1','clasificacion':'Alto'}]
valoraciones=[{'id':'1','valor':10}]
plan = generate_treatments(riesgos)
print('Plan:', plan)
res = calculate_residual(plan, valoraciones, riesgos)
print('Residual:', res)
PY`

------
https://chatgpt.com/codex/tasks/task_e_686dc5c74608832caf5ae97b1756eaea