### PR TITLE
Fix PDF export byte handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,7 +167,7 @@ def export(domain, fmt):
                 wrapmode=WrapMode.CHAR
             )
 
-        pdf_bytes = pdf.output(dest='S').encode('latin-1')
+        pdf_bytes = bytes(pdf.output())
         resp = make_response(pdf_bytes)
         resp.headers['Content-Disposition'] = f'attachment; filename={domain}.pdf'
         resp.headers['Content-Type'] = 'application/pdf'


### PR DESCRIPTION
## Summary
- fix PDF export after fpdf2 update

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686dea7cebd4832c85cfbccb795facb4